### PR TITLE
Fixed typos in DistillRenderer.get_uri_values

### DIFF
--- a/django_distill/renderer.py
+++ b/django_distill/renderer.py
@@ -54,9 +54,9 @@ class DistillRender(object):
             raise DistillError('Failed to call distill function: {}'.format(e))
         if not v:
             return (None,)
-        elif isinstance(t, (list, tuple)):
+        elif isinstance(v, (list, tuple)):
             return v
-        elif isinstance(t, types.GeneratorType):
+        elif isinstance(v, types.GeneratorType):
             return list(v)
         else:
             err = 'Distill function returned an invalid type: {}'


### PR DESCRIPTION
When running the `distill-local` command with distill URLs using a function that returns either a list, a tuple, or is a generator, a `NameError: name 't' is not defined` error is raised in renderer.py, method get_uri_values of class DistillRenderer, in line 57 for a list and a tuple, and 59 for a generator.

I checked the code, and it seems there are typos in [these lines](https://github.com/mgrp/django-distill/blob/63c5c9ca20672b93ed853d2fb2ae259ab1002c27/django_distill/renderer.py#L57-L60) – instead of using the `v` variable created in the try block at the beginning of the method, an undefined `t` variable is used, which causes the error:

```
elif isinstance(t, (list, tuple)):
    return v
elif isinstance(t, types.GeneratorType):
    return list(v)
```

Simply renaming the variable name fixes the problem and allows running the command with no problem. I'm assuming this is the appropriate fix, so I'm creating this PR with the fixed code.