### PR TITLE
Auto detect index files

### DIFF
--- a/django_distill/renderer.py
+++ b/django_distill/renderer.py
@@ -42,6 +42,12 @@ class DistillRender(object):
                     param_set = param_set,
                 uri = self.generate_uri(view_name, param_set)
                 render = self.render_view(uri, param_set, a)
+                # auto detect URIs ending with a slash, rewrite them to "/index.html"
+                if file_name is None and uri.endswith("/"):
+                    if uri.startswith("/"):
+                        uri = uri[1:]
+                    yield uri, uri + "index.html", render
+                    continue
                 yield uri, file_name, render
 
     def _is_str(self, s):


### PR DESCRIPTION
This PR makes django-distill easier to use with uris ending with a `/`.

**Example**

A URL like this
```
distill_url(
         r'^foo/(?P<bar>[-\w]+)/$',
        View.as_view(),
        distill_func=get_main,
),
```

is rewritten to something like `foo/<bar>/index.html`.
*This wasn't possible before because `distill_file` is just accepting a hardcoded string and won't replace `<bar>` with the actual kwarg*

This also applies to the example mentioned in the docs. It's no longer neccessary to have a special rule for the empty index file.

Instead of

```
distill_url(r'^$',
                PostIndex.as_view(),
                name='blog-index',
                distill_func=get_index,
                # / is not a valid file name! override it to index.html
                distill_file='index.html'),
```

you can just use

```
distill_url(r'^$',
        PostIndex.as_view(),
        name='blog-index',
        distill_func=get_index
),
```