### PR TITLE
fix bug in boto with bucket names that contain a dot

### DIFF
--- a/django_distill/backends/amazon_s3.py
+++ b/django_distill/backends/amazon_s3.py
@@ -46,6 +46,8 @@ class AmazonS3Backend(BackendBase):
         except CertificateError as e:
             # There's a well known bug in boto with buckets that contain a dot like
             # 'my.bucket.com': https://github.com/boto/boto/issues/2836
+            if calling_format:
+                raise e
             self.authenticate(calling_format=OrdinaryCallingFormat())
 
 

--- a/django_distill/backends/amazon_s3.py
+++ b/django_distill/backends/amazon_s3.py
@@ -6,7 +6,7 @@ import warnings
 
 
 try:
-    from boto.s3.connection import S3Connection
+    from boto.s3.connection import S3Connection, OrdinaryCallingFormat
     from boto.s3.key import Key
 except ImportError:
     l = 'django_distill.backends.amazon_s3'
@@ -18,7 +18,7 @@ except ImportError:
 
 from django_distill.errors import DistillPublishError
 from django_distill.backends import BackendBase
-
+from ssl import CertificateError
 
 class AmazonS3Backend(BackendBase):
     '''
@@ -34,12 +34,20 @@ class AmazonS3Backend(BackendBase):
     def account_container(self):
         return self.options.get('BUCKET', '')
 
-    def authenticate(self):
+    def authenticate(self, calling_format=None):
         access_key_id = self.account_username()
         secret_access_key = self.options.get('SECRET_ACCESS_KEY', '')
         bucket = self.account_container()
-        self.d['connection'] = S3Connection(access_key_id, secret_access_key)
-        self.d['bucket'] = self.d['connection'].get_bucket(bucket)
+
+        try:
+            kwargs = {} if calling_format is None else {"calling_format": calling_format}
+            self.d['connection'] = S3Connection(access_key_id, secret_access_key, **kwargs)
+            self.d['bucket'] = self.d['connection'].get_bucket(bucket)
+        except CertificateError as e:
+            # There's a well known bug in boto with buckets that contain a dot like
+            # 'my.bucket.com': https://github.com/boto/boto/issues/2836
+            self.authenticate(calling_format=OrdinaryCallingFormat())
+
 
     def list_remote_files(self):
         rtn = set()


### PR DESCRIPTION
There's a well known bug in boto with bucket names that contain a dot: https://github.com/boto/boto/issues/2836

This is a workaround that catches the underlying `CertificateError` and tries to re-authenticate by changing the calling format to `OrdinaryCallingFormat`.